### PR TITLE
fix: Make `l` alias list files only once

### DIFF
--- a/conf.d/fish-exa.fish
+++ b/conf.d/fish-exa.fish
@@ -1,4 +1,4 @@
-alias l 'exa $argv'
+alias l 'exa'
 alias ll 'exa_git'
 alias la 'exa $EXA_STANDARD_OPTIONS $EXA_LA_OPTIONS'
 alias ld 'exa $EXA_STANDARD_OPTIONS $EXA_LD_OPTIONS'


### PR DESCRIPTION
The `l` alias contains the `$argv` variable, so exa is called with all its arguments doubled.

For options, this makes no difference, but when using `l` to display files besides the current directory, the listing is doubled:
```
$ l /
/:
bin   cdrom  etc   lib    lib64   lost+found  mnt  proc  run   snap  Store  tmp  var
boot  dev    home  lib32  libx32  media       opt  root  sbin  srv   sys    usr  

/:
bin   cdrom  etc   lib    lib64   lost+found  mnt  proc  run   snap  Store  tmp  var
boot  dev    home  lib32  libx32  media       opt  root  sbin  srv   sys    usr  
```

With the proposed change, this works a expected, listing the files only once:

```
$ l /
bin   cdrom  etc   lib    lib64   lost+found  mnt  proc  run   snap  Store  tmp  var
boot  dev    home  lib32  libx32  media       opt  root  sbin  srv   sys    usr  
```